### PR TITLE
fix: Use sqlalchemy.orm.declarative_base

### DIFF
--- a/casbin_async_sqlalchemy_adapter/adapter.py
+++ b/casbin_async_sqlalchemy_adapter/adapter.py
@@ -18,9 +18,8 @@ from casbin import persist
 from sqlalchemy import Column, Integer, String
 from sqlalchemy import or_
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.future import select
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 Base = declarative_base()
 


### PR DESCRIPTION
`sqlalchemy.orm.ext.declarative_base` is deprecated(from 1.4)
To avoid warning, i suggest to change import path to `sqlalchemy.orm.declarative_base`
https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.declarative_base
